### PR TITLE
Fix exit problem in interactive client

### DIFF
--- a/UnitTests/ProcedureTest.cs
+++ b/UnitTests/ProcedureTest.cs
@@ -55,6 +55,10 @@ public sealed class ProcedureTest
 
         DaemonServer daemonServer = MapepireTest.GetTestDaemonServer();
         string successString = "connection created using (" + MapepireTest.host + "," + MapepireTest.port + "," + MapepireTest.user + ",*******)";
+        Console.WriteLine("Host: " + daemonServer.Host);
+        Console.WriteLine("Port: " + daemonServer.Port);
+        Console.WriteLine("User: " + daemonServer.User);
+
         SqlJob job = new();
         ConnectionResult? cr = job.Connect(daemonServer);
 

--- a/io/github/mapepire_ibmi/InteractiveClient.cs
+++ b/io/github/mapepire_ibmi/InteractiveClient.cs
@@ -10,24 +10,15 @@ public class InteractiveClient {
 	public static void Main(string[] args) {
 
 		Console.WriteLine("Running interactive MapepireClient");
-		try {
-			
-			string? line = Console.ReadLine();
-			bool running = true;
-			while (line != null && running) {
-				running = ProcessLine(line);
-				line = Console.ReadLine();
-			}
-
-		} catch (Exception e) {
-			Console.WriteLine("Severe failure");
-			Console.WriteLine(e.StackTrace);
-		}
+		while (ProcessLine());
 	}
 
-	private static bool ProcessLine(string line) {
-
-		try { 
+	private static bool ProcessLine() {
+		string? line = null;
+		try {
+		line = Console.ReadLine();
+		if (line == null) return false;
+		
 		string[] lineElements = splitLine(line);
 		if (lineElements.Length > 0) {
             string command = lineElements[0].ToLowerInvariant(); 


### PR DESCRIPTION
1. Fix exit problem in interactive client
We need to type "exit" twice to exit from InteractiveClient. We should only need to type it once.
2. Add temporary trace messages in ProcedureTest.NumberParameters() to log connection host and user profile. This is to identify the cause of a test failure in automated tests. The trace messages will be removed later.