### PR TITLE
Check configResult to determine if tracing is enabled on server

### DIFF
--- a/UnitTests/TraceTest.cs
+++ b/UnitTests/TraceTest.cs
@@ -73,7 +73,13 @@ public sealed class  TraceTest
         SqlJob job = new(); 
 		ConnectionResult? cr = job.Connect(daemonServer);
      
-        job.SetTraceLevel(level);
+        // If the config result indicates that tracing is not enabled at the server side,
+        // then set traceExists to false.
+        SetConfigResult configResult = job.SetTraceLevel(level);
+        if (configResult.JtOpenTraceLevel?.ToUpper() == "OFF") {
+            traceExists = false;
+        }
+
         Query query = job.Query(sql);
 
             try {


### PR DESCRIPTION
Currently there is an issue in Mapepire server that tracing is not enabled in daemon mode. In client trace tests, we will check the returned config result to determine if tracing is enabled on server. If it is not enabled, we will skip the client trace tests.